### PR TITLE
Update PCBSD build info

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ First, cd to the "pcbsd" sub-directory and make a copy of the following:
 
 ```
 # cp pcbsd.cfg.dist pcbsd.cfg
-# cp pkg-dist pkg
-# cp pbi-dist pbi
+# cp -R pkg-dist/ pkg/
+# cp -R pbi-dist/ pbi/
 ```
 
 Next, you will want to edit pcbsd.cfg and check that the options are correct
@@ -106,15 +106,6 @@ To start a build, run "make" in the source directory. FreeBSD sources will be
 downloaded from GIT automatically, and then a world / kernel built. Once
 this build finishes, the builder will begin compiling packages with poudriere.
 Lastly the ISO will be built in the ~/iso directory.
-
-Before you can run "make image" you must have unicode.pf2 in /usr/local/share/grub/.
-You can copy /boot/grub/pcbsdfont.pf2 if you have PC-BSD installed.  
-
-```
-# cp /boot/grub/pcbsdfont.pf2 /usr/local/share/grub/unicode.pf2
-```
-
-Alternatively you may fetch pcbsdfont.pf2 from PC-BSD github.
 
 
 Advanced Usage:


### PR DESCRIPTION
The cp command needs -R to copy directories.  It is no longer required to fetch the "pcbsdfont.pf2" file to build.
