### PR TITLE
Remove editors/libreoffice

### DIFF
--- a/iocage/iocage-ports
+++ b/iocage/iocage-ports
@@ -4,7 +4,6 @@ databases/postgresql95-contrib
 databases/postgresql95-client
 devel/jenkins
 devel/jenkins-lts
-editors/libreoffice
 games/minecraft-server
 multimedia/emby-server
 multimedia/plexmediaserver


### PR DESCRIPTION
libpreoffice dependes on science/szip which have change the License (https://svnweb.freebsd.org/ports/head/science/szip/Makefile?r1=471800&r2=471799&pathrev=471800) with this change we are not able to distribute packages for libpreoffice any longer. As a side note have not found any plugin which relay on libpreoffice.